### PR TITLE
Fix task completion status utility

### DIFF
--- a/helpers/getTaskCompletionStatus.tsx
+++ b/helpers/getTaskCompletionStatus.tsx
@@ -2,14 +2,12 @@ import dayjs from "dayjs";
 
 export const getTaskCompletionStatus = (task, iteration): boolean => {
   if (task.recurrenceRule) {
-    return (
-      iteration &&
-      task.completionInstances.find(
-        (instance) =>
-          dayjs(instance.iteration || instance.recurrenceDay).isValid() &&
-          dayjs(instance.iteration || instance.recurrenceDay).toISOString() ===
-            dayjs(iteration.toString()).toISOString()
-      )
+    if (!iteration) return false;
+    return task.completionInstances.some(
+      (instance) =>
+        dayjs(instance.iteration || instance.recurrenceDay).isValid() &&
+        dayjs(instance.iteration || instance.recurrenceDay).toISOString() ===
+          dayjs(iteration.toString()).toISOString()
     );
   } else {
     return task.completionInstances.length > 0;


### PR DESCRIPTION
## Summary
- ensure `getTaskCompletionStatus` always returns a boolean

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/compat')*

------
https://chatgpt.com/codex/tasks/task_e_683f702af7c4832e8c0420ab2a123f4d